### PR TITLE
Remove hardcoded loglevel

### DIFF
--- a/services/htpcmanager/run
+++ b/services/htpcmanager/run
@@ -1,3 +1,3 @@
 #!/bin/bash
-/sbin/setuser abc python /app/htpcmanager/Htpc.py --loglevel info --datadir /config
+/sbin/setuser abc python /app/htpcmanager/Htpc.py --datadir /config
 


### PR DESCRIPTION
I want to remove the hardcoded loglevel all command line params overrides any settings in the db.
By omitting loglevel it will default to loglevel info or what ever the user has set in the settings.
